### PR TITLE
bump @pinecone-database/pinecone to v7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "minimal-pinecone-app",
       "version": "1.0.0",
       "dependencies": {
-        "@pinecone-database/pinecone": "git+https://github.com/pinecone-io/pinecone-ts-client.git#adenoble/update-data-plane-namespace-targeting",
+        "@pinecone-database/pinecone": "^7.0.0",
         "edge-runtime": "^3.0.3",
         "next": "^16.1.0"
       },
@@ -668,8 +668,9 @@
       }
     },
     "node_modules/@pinecone-database/pinecone": {
-      "version": "6.1.4",
-      "resolved": "git+ssh://git@github.com/pinecone-io/pinecone-ts-client.git#7f6c42f371f310478660b54c6ef94361fbcf4d8f",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-7.0.0.tgz",
+      "integrity": "sha512-/+SzpIJPXhrwv27CCz+sFw/r22Sjk9s+i8nFTryPiQAcwgWmWRWFqT1/LGkTdd9NRhuEA48yaCx/HgM6ugLNJA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@pinecone-database/pinecone": "git+https://github.com/pinecone-io/pinecone-ts-client.git#adenoble/update-data-plane-namespace-targeting",
+    "@pinecone-database/pinecone": "^7.0.0",
     "edge-runtime": "^3.0.3",
     "next": "^16.1.0"
   },


### PR DESCRIPTION
## Problem
Until the major version of the node SDK was released, the dependency for the node SDK was pointing at a branch.

## Solution
Update to the latest v7.0.0 of the node SDK.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI